### PR TITLE
Fix catalog-info.yaml team slug for Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   type: tool
   lifecycle: experimental
-  owner: site
+  owner: site-experience


### PR DESCRIPTION
## Summary
Update catalog owner from `site` to `site-experience` (full team slug).

## Why
Backstage requires the complete team slug for proper team resolution and service catalog organization. The abbreviated `site` slug does not resolve correctly in the service catalog, causing ownership to appear as "stale" in the catalog.

## Changes
- catalog-info.yaml: `owner: site` → `owner: site-experience`

## Notes
- CODEOWNERS already has correct team reference
- No other files reference the old slug
- This is purely a Backstage catalog metadata fix

## Jira
[DELENG-392](https://getpantheon.atlassian.net/browse/DELENG-392)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DELENG-392]: https://getpantheon.atlassian.net/browse/DELENG-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ